### PR TITLE
fix: correct braces in fp-lib-table

### DIFF
--- a/fp-lib-table
+++ b/fp-lib-table
@@ -1,4 +1,4 @@
 (fp_lib_table
   (version 7)
-  (lib (name "tt")(type "KiCad")(uri "$(KIPRJMOD}/../kicad-tinytapeout-pmod-lib/TinyTapeout_PMOD.pretty")(options "")(descr ""))
+  (lib (name "tt")(type "KiCad")(uri "${KIPRJMOD}/../kicad-tinytapeout-pmod-lib/TinyTapeout_PMOD.pretty")(options "")(descr ""))
 )


### PR DESCRIPTION
This fixes the braces around the `KIPRJMOD` variable, so that the symbol library can be found.